### PR TITLE
fix: remove deprecated ast.Num/ast.Str checks in calculator

### DIFF
--- a/runprompt
+++ b/runprompt
@@ -2317,10 +2317,6 @@ def calculator(expression: str):
                 return node.value
             raise ValueError("Only numbers allowed, not %s" %
                              type(node.value).__name__)
-        elif isinstance(node, ast.Num):
-            return node.n
-        elif isinstance(node, ast.Str):
-            raise ValueError("Only numbers allowed, not str")
         elif isinstance(node, ast.BinOp):
             if type(node.op) not in allowed_ops:
                 raise ValueError("Operation not allowed: %s" %


### PR DESCRIPTION
## What changed
- Removed deprecated `ast.Num` and `ast.Str` branches from the `calculator` AST evaluator.
- Kept validation behavior unchanged by handling numeric and non-numeric literals through `ast.Constant` only.

## Why
- `ast.Num` and `ast.Str` are deprecated aliases and emit deprecation warnings on modern Python versions.
- This keeps the calculator implementation forward-compatible without changing runtime behavior.

## Testing
- `pytest -q`  
  Tests: not run (no tests found)
- `python3 tests/test-calculator.py` (pass: 26 passed, 0 failed)
