### PR TITLE
Fix crash when OpenAI-compatible API returns `tool_calls: null`

### DIFF
--- a/runprompt
+++ b/runprompt
@@ -1194,7 +1194,7 @@ def extract_response(response, output_config):
             if block.get("type") == "tool_use" and block.get("name") == "extract":
                 return json.dumps(block.get("input", {}), indent=2)
     elif "choices" in response:  # OpenAI
-        for tc in response["choices"][0].get("message", {}).get("tool_calls", []):
+        for tc in (response["choices"][0].get("message", {}).get("tool_calls") or []):
             if tc.get("function", {}).get("name") == "extract":
                 return tc.get("function", {}).get("arguments", "{}")
     return extract_text_content(response)
@@ -1219,7 +1219,7 @@ def extract_tool_calls(response):
                     "arguments": block.get("input", {}),
                 })
     elif "choices" in response:  # OpenAI
-        for tc in response["choices"][0].get("message", {}).get("tool_calls", []):
+        for tc in (response["choices"][0].get("message", {}).get("tool_calls") or []):
             args_str = tc.get("function", {}).get("arguments", "{}")
             try:
                 args = json.loads(args_str)

--- a/tests/test-tools.py
+++ b/tests/test-tools.py
@@ -761,6 +761,30 @@ def test_safe_yes_still_prompts_unsafe_tools():
         server.shutdown()
 
 
+def test_tool_calls_null_no_crash():
+    """Test that a response with tool_calls: null does not crash."""
+    responses = [
+        {"choices": [{"message": {"role": "assistant", "content": "Hello!", "tool_calls": None}}]}
+    ]
+    server = start_server(MOCK_PORT + 15, responses)
+    try:
+        env = os.environ.copy()
+        env['OPENAI_BASE_URL'] = 'http://127.0.0.1:%d' % (MOCK_PORT + 15)
+        env['OPENAI_API_KEY'] = 'test-key'
+        result = subprocess.run(
+            ['./runprompt', '--model', 'openai/gpt-4o', '--tools=sample_tools.greet',
+             '--tool-path=tests', 'tests/hello.prompt'],
+            capture_output=True,
+            text=True,
+            env=env,
+            input='{"name": "World"}'
+        )
+        assert result.returncode == 0, "Expected success, got: %s" % result.stderr
+        assert 'Hello!' in result.stdout, "Expected model reply in output"
+    finally:
+        server.shutdown()
+
+
 if __name__ == '__main__':
     test("tools sent in request", test_tools_sent_in_request)
     test("tool schema generation", test_tool_schema_generation)
@@ -777,6 +801,7 @@ if __name__ == '__main__':
     test("builtin write_file execution", test_builtin_write_file_execution)
     test("builtin factory without args warns", test_builtin_factory_without_args_warns)
     test("builtin wildcard skips factories", test_builtin_wildcard_skips_factories)
+    test("tool_calls: null does not crash", test_tool_calls_null_no_crash)
 
     print("")
     print("Passed: %d, Failed: %d" % (passed, failed))


### PR DESCRIPTION
Some OpenAI-compatible APIs return `"tool_calls": null` in the message object when no tools are called, rather than omitting the key entirely.

`.get("tool_calls", [])` only substitutes the default for a missing key, so an explicit `null` passed through as `None`, causing a `TypeError` when iterating.

This fixes both `extract_response` and `extract_tool_calls` to use `or []` so either case (missing key or explicit null) is handled safely.