### PR TITLE
Allow skipping tls verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ Configuration values can be set from config file, env var or command line flag, 
 | Verbose | `verbose: true` | `RUNPROMPT_VERBOSE=1` | `--verbose` |
 | Chat | `chat: true` | `RUNPROMPT_CHAT=1` | `--chat` |
 | LLM timeout | `timeout: 120` | `RUNPROMPT_TIMEOUT=120` | `--timeout 120` |
+| Insecure | `insecure: true` | `RUNPROMPT_INSECURE=1` | `--insecure` |
 
 ### API keys
 
@@ -604,6 +605,8 @@ export BASE_URL="http://localhost:11434/v1"
 ```
 
 When a custom base URL is set, the provider prefix in the model string is ignored and the OpenAI-compatible API format is used.
+
+Use `--insecure` or `insecure: true` to disable TLS certificate verification when targeting self-signed endpoints.
 
 ### Verbose mode
 

--- a/runprompt
+++ b/runprompt
@@ -28,6 +28,7 @@ import glob
 import base64
 import mimetypes
 import socket
+import ssl
 
 # Try to use PyYAML if available, otherwise use minimal parser
 try:
@@ -49,6 +50,7 @@ CONFIG_KEYS = {
     "openai_base_url", "openai_api_base", "cache", "cache_dir",
     "safe_yes", "verbose", "anthropic_api_key", "openai_api_key",
     "google_api_key", "openrouter_api_key", "chat", "chat_history", "history_file", "timeout",
+    "insecure",
 }
 
 PROVIDERS = {
@@ -176,6 +178,8 @@ def init_config(args):
     for key, value in args.overrides.items():
         args_dict[normalize_key(key)] = value
     CONFIG["args"] = args_dict
+    if get_conf("insecure"):
+        ssl._create_default_https_context = ssl._create_unverified_context
 
 
 def get_timeout():
@@ -623,6 +627,8 @@ def parse_args(args):
                         help="Interactive chat mode: prompt for input after each response")
     parser.add_argument("--timeout", type=float, metavar="SECONDS",
                         help="LLM request timeout in seconds")
+    parser.add_argument("--insecure", action="store_true",
+                        help="Disable TLS certificate verification")
     parser.add_argument("--read", "--file", action="append", default=[],
                         metavar="FILE",
                         help="Read file(s) into context (supports globs)")


### PR DESCRIPTION
Local endpoints may be deployed with self-signed certificates, which Python rejects.

This PR adds an opt-in way to skip validation, following the existing patterns. Default behavior remains unchanged.

(Copy of https://github.com/chr15m/runprompt/pull/32, simply moved into a separate branch)